### PR TITLE
Beef up the circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,18 +26,9 @@ jobs:
           command: |
             echo "export BUILD_VERSION=$(date +%Y%m%d%H%M)-$CIRCLE_BUILD_NUM" >> $BASH_ENV
       - deploy:
-          name: Build Container
+          name: Build Fat Jar
           command: |
-            docker build . \
-              --tag "mojdigitalstudio/pdf-generator:$BUILD_VERSION" \
-              --label "maintainer=noms-studio-webops@digital.justice.gov.uk" \
-              --label "build.number=$CIRCLE_BUILD_NUM" \
-              --label "build.url=$CIRCLE_BUILD_URL" \
-              --label "build.gitref=$CIRCLE_SHA1"
-
-            mkdir -p ./build/container
-            docker image save \
-              -o "build/container/pdf-generator-container-image-$BUILD_VERSION.tar" \
-              "mojdigitalstudio/pdf-generator:$BUILD_VERSION"
+            mkdir -p ./build/artifacts
+            mv build/libs/pdfGenerator.jar ./build/artifacts/pdf-generator-$BUILD_VERSION.jar
       - store_artifacts:
-          path: ./build/container
+          path: ./build/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
           key: dotgradle-{{ checksum "build.gradle" }}
       - store_test_results:
           path: ./build/test-results/test/
-      - setup_remote_docker
       - run:
           name: Generate Build version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,22 @@
 version: 2
 
 jobs:
-    build:
-        working_directory: ~/pdf-generator
-        docker:
-            - image: openjdk:8
-        steps:
-            - checkout
-            - setup_remote_docker
-            - run:
-                name: Run gradle build
-                command: ./gradlew build
+  build:
+    working_directory: ~/app
+    docker:
+      - image: openjdk:8
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - jars-{{ checksum "build.gradle" }}
+            - jars-
+      - run:
+          name: Run gradle build
+          command: ./gradlew build
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}
+      - store_test_results:
+          path: ./build/test-results/test/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,40 @@ jobs:
   build:
     working_directory: ~/app
     docker:
-      - image: openjdk:8
+      - image: circleci/openjdk:8
     steps:
       - checkout
       - restore_cache:
           keys:
-            - jars-{{ checksum "build.gradle" }}
-            - jars-
+            - dotgradle-{{ checksum "build.gradle" }}
+            - dotgradle-
       - run:
           name: Run gradle build
           command: ./gradlew build
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}
+          key: dotgradle-{{ checksum "build.gradle" }}
       - store_test_results:
           path: ./build/test-results/test/
+      - setup_remote_docker
+      - run:
+          name: Generate Build version
+          command: |
+            echo "export BUILD_VERSION=$(date +%Y%m%d%H%M)-$CIRCLE_BUILD_NUM" >> $BASH_ENV
+      - deploy:
+          name: Build Container
+          command: |
+            docker build . \
+              --tag "mojdigitalstudio/pdf-generator:$BUILD_VERSION" \
+              --label "maintainer=noms-studio-webops@digital.justice.gov.uk" \
+              --label "build.number=$CIRCLE_BUILD_NUM" \
+              --label "build.url=$CIRCLE_BUILD_URL" \
+              --label "build.gitref=$CIRCLE_SHA1"
+
+            mkdir -p ./build/container
+            docker image save \
+              -o "build/container/pdf-generator-container-image-$BUILD_VERSION.tar" \
+              "mojdigitalstudio/pdf-generator:$BUILD_VERSION"
+      - store_artifacts:
+          path: ./build/container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             echo "export BUILD_VERSION=$(date +%Y%m%d%H%M)-$CIRCLE_BUILD_NUM" >> $BASH_ENV
       - deploy:
-          name: Build Fat Jar
+          name: Save Fat Jar
           command: |
             mkdir -p ./build/artifacts
             mv build/libs/pdfGenerator.jar ./build/artifacts/pdf-generator-$BUILD_VERSION.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM openjdk:8
-
-MAINTAINER Nick Talbot <nick.talbot@digital.justice.gov.uk>
+FROM openjdk:8-jre-alpine
 
 COPY build/libs/pdfGenerator.jar /root/
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,6 @@ dependencies {
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
     testCompile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 }
+
+// Always run tests, because why wouldn't you?
+test.outputs.upToDateWhen {false}


### PR DESCRIPTION
* Parse test result xml
* speed up build with caching
* build the container on circle
* store the built container for later use
* use a much more lightweight container base